### PR TITLE
Specify full key ID for apt-key

### DIFF
--- a/installROS.sh
+++ b/installROS.sh
@@ -87,7 +87,7 @@ sudo apt-add-repository restricted
 # Setup sources.lst
 sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
 # Setup keys
-sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 0xB01FA116
+sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
 # Installation
 tput setaf 2
 echo "Updating apt-get"


### PR DESCRIPTION
Using short key ID is discouraged, as it may download multiple signing key. It is better to follow current installation instructions of ROS. In fact, there are already two keys with this short ID on the key server. One official key and one suspicious key called "Totally Legit Signing Key".
